### PR TITLE
General cleanup, packaging conventions

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@ To use:
 
 1. Get an API key for [[https://peekalink.io]] and set ~PEEKALINK_API_KEY~ in your environment
 2. Move your cursor to a link
-3. Run ~(lp/expand-link-at-cursor)~
+3. Run ~(link-preview-insert)~
 4. OG title and description will be inserted below
 
 

--- a/link-preview.el
+++ b/link-preview.el
@@ -3,7 +3,8 @@
 ;; Copyright (C) 2022 Avi Press
 ;; Author: Avi Press <mail@avi.press>
 ;; Version: 1.0
-;; URL: https://github.com/aviaviavi/link-preview-emacs
+;; URL: https://github.com/aviaviavi/link-preview.el
+;; Package-Requires: ((request "20210816.200"))
 
 ;;; Commentary:
 
@@ -14,11 +15,11 @@
 (require 'json)
 (require 'request)
 
-(setq link-preview-api "https://api.peekalink.io/")
-
-(defun lp/expand-link-at-cursor ()
+(defun link-preview-insert ()
+  "Injects a link preview for the URL under your cursor."
   (interactive)
-  (setq link-preview-url (thing-at-point 'url))
+  (let ((link-preview-api "https://api.peekalink.io/")
+        (link-preview-url (thing-at-point 'url)))
   (message "json: %S" (json-encode `(("link" . ,link-preview-url))))
   (request link-preview-api
     :type "POST"
@@ -36,12 +37,11 @@
                 (insert (assoc-default 'title data))
                 (newline-and-indent)
                 (insert (assoc-default 'description data))
-                (newline-and-indent)
-                ))
+                (newline-and-indent)))
     :complete (lambda (&rest _) (message "Finished!"))
     :error
     (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                  (message "Got error: %S" error-thrown)))))
+                  (message "Got error: %S" error-thrown))))))
 
-
-
+(provide 'link-preview)
+;;; link-preview.el ends here


### PR DESCRIPTION
Closes #2 

- Dependency info
- Docstring
- `provide` pragma
- renames the main function according to conventions